### PR TITLE
feat(support M1 architecture)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ path = "lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-rodio = "0.12.0"
-deno_bindgen = "0.5.0"
+rodio = "0.17.1"
+deno_bindgen = "0.8.1"


### PR DESCRIPTION
This commit updates cargo.toml and generates new bindings, which supports a wider range of architectures, in particular Apple M1. Resolves #9.